### PR TITLE
Add missing effects and replace CardId with Card in choice

### DIFF
--- a/Tests/Board/BoardManagerTests.cs
+++ b/Tests/Board/BoardManagerTests.cs
@@ -36,8 +36,9 @@ public class BoardManagerTests
     void TestBasicExecutionChainInteraction()
     {
         var sut = new BoardManager(new[] { PatronId.ANSEI });
-        sut.Players[0].Hand.Add(GlobalCardDatabase.Instance.GetCard(CardId.CONQUEST));
-        var chain = sut.PlayCard(CardId.CONQUEST);
+        var conquest = GlobalCardDatabase.Instance.GetCard(CardId.CONQUEST);
+        sut.Players[0].Hand.Add(conquest);
+        var chain = sut.PlayCard(conquest);
         var flag = 0;
 
         foreach (var result in chain.Consume())
@@ -65,7 +66,7 @@ public class BoardManagerTests
         sut.CurrentPlayer.CoinsAmount = 100;
 
         var card = sut.Tavern.AvailableCards.First();
-        sut.BuyCard(card.Id);
+        sut.BuyCard(card);
 
         Assert.Contains(
             card.Id,
@@ -90,7 +91,7 @@ public class BoardManagerTests
         sut.SetUpGame();
 
         var card = sut.Tavern.AvailableCards.First();
-        Assert.Throws<Exception>(() => sut.BuyCard(card.Id));
+        Assert.Throws<Exception>(() => sut.BuyCard(card));
     }
 
     [Fact]

--- a/Tests/Board/ExecutionChainTests.cs
+++ b/Tests/Board/ExecutionChainTests.cs
@@ -30,7 +30,7 @@ public class ExecutionChainTests
         Assert.True(result is Choice<EffectType>);
         var choice = result as Choice<EffectType>;
         var newResult = choice.Choose(EffectType.ACQUIRE_TAVERN);
-        Assert.True(newResult is Choice<CardId>);
+        Assert.True(newResult is Choice<Card>);
         Assert.Throws<Exception>(() => consume.MoveNext());
     }
 
@@ -63,8 +63,10 @@ public class ExecutionChainTests
     {
         // SETUP
         _sut = new ExecutionChain(_player1, _player2, _tavern);
-        _player1.DrawPile.Add(GlobalCardDatabase.Instance.GetCard(CardId.GOLD));
-        _player1.DrawPile.Add(GlobalCardDatabase.Instance.GetCard(CardId.GOLD));
+        var gold1 = GlobalCardDatabase.Instance.GetCard(CardId.GOLD);
+        var gold2 = GlobalCardDatabase.Instance.GetCard(CardId.GOLD);
+        _player1.DrawPile.Add(gold1);
+        _player1.DrawPile.Add(gold2);
 
         // First - OR choice and immediately TOSS choice
         var effect1 = new EffectChoice(new Effect(EffectType.GAIN_POWER, 1),
@@ -97,9 +99,9 @@ public class ExecutionChainTests
                     Assert.True(result is Choice<EffectType>);
                     var choice = result as Choice<EffectType>;
                     var newResult = choice.Choose(EffectType.TOSS);
-                    Assert.True(newResult is Choice<CardId>);
-                    var newChoice = newResult as Choice<CardId>;
-                    Assert.True(newChoice.Choose(CardId.GOLD) is Success);
+                    Assert.True(newResult is Choice<Card>);
+                    var newChoice = newResult as Choice<Card>;
+                    Assert.True(newChoice.Choose(gold1) is Success);
                     break;
                 }
                 // Should be power gain
@@ -112,9 +114,9 @@ public class ExecutionChainTests
                 // Should be standalone TOSS choice
                 case 2:
                     {
-                        Assert.True(result is Choice<CardId>);
-                        var choice = result as Choice<CardId>;
-                        var newResult = choice.Choose(CardId.GOLD);
+                        Assert.True(result is Choice<Card>);
+                        var choice = result as Choice<Card>;
+                        var newResult = choice.Choose(gold2);
                         Assert.True(newResult is Success);
                         break;
                     }

--- a/Tests/Board/PlayResultTests.cs
+++ b/Tests/Board/PlayResultTests.cs
@@ -17,8 +17,8 @@ public class PlayResultTests
     [Fact]
     void ShouldNotAllowTooManyChoices()
     {
-        var sut = new Choice<EffectType>(new List<EffectType> { EffectType.DRAW, EffectType.HEAL, EffectType.TOSS }, 1,
-            _ => new Success());
+        var sut = new Choice<EffectType>(new List<EffectType> { EffectType.DRAW, EffectType.HEAL, EffectType.TOSS },
+            _ => new Success(), 1);
 
         var result = sut.Choose(new List<EffectType> { EffectType.HEAL, EffectType.TOSS });
         Assert.True(result is Failure);
@@ -27,8 +27,8 @@ public class PlayResultTests
     [Fact]
     void ShouldNotAllowIncorrectChoices()
     {
-        var sut = new Choice<EffectType>(new List<EffectType> { EffectType.DRAW, EffectType.HEAL, EffectType.TOSS }, 2,
-            _ => new Success());
+        var sut = new Choice<EffectType>(new List<EffectType> { EffectType.DRAW, EffectType.HEAL, EffectType.TOSS },
+            _ => new Success(), 2);
 
         var result = sut.Choose(new List<EffectType> { EffectType.HEAL, EffectType.DESTROY_CARD });
         Assert.True(result is Failure);
@@ -47,10 +47,30 @@ public class PlayResultTests
     [Fact]
     void ShouldPassCorrectMultipleChoice()
     {
-        var sut = new Choice<EffectType>(new List<EffectType> { EffectType.DRAW, EffectType.HEAL, EffectType.TOSS }, 2,
-            _ => new Success());
+        var sut = new Choice<EffectType>(new List<EffectType> { EffectType.DRAW, EffectType.HEAL, EffectType.TOSS },
+            _ => new Success(), 2);
 
         var result = sut.Choose(new List<EffectType> { EffectType.HEAL, EffectType.TOSS });
         Assert.True(result is Success);
+    }
+    
+    [Fact]
+    void ShouldNotAllowTooFewChoices()
+    {
+        var sut = new Choice<EffectType>(new List<EffectType> { EffectType.DRAW, EffectType.HEAL, EffectType.TOSS },
+            _ => new Success(), 2, 2);
+
+        var result = sut.Choose(new List<EffectType> { EffectType.HEAL });
+        Assert.True(result is Failure);
+    }
+
+    [Fact]
+    void ShouldNotAllowTooFewChoicesOverload()
+    {
+        var sut = new Choice<EffectType>(new List<EffectType> { EffectType.DRAW, EffectType.HEAL, EffectType.TOSS },
+            _ => new Success(), 2, 2);
+
+        var result = sut.Choose(EffectType.HEAL);
+        Assert.True(result is Failure);
     }
 }

--- a/Tests/Board/PlayerTests.cs
+++ b/Tests/Board/PlayerTests.cs
@@ -11,13 +11,14 @@ public class PlayerTests
     [Fact]
     void TestAcquireCardFlowWithContractAction()
     {
-        // Contract Action with Coin 2
-        _tavern.AvailableCards.Add(GlobalCardDatabase.Instance.GetCard(CardId.KWAMA_EGG_MINE));
+        var contractActionWithCoin2 = GlobalCardDatabase.Instance.GetCard(CardId.KWAMA_EGG_MINE);
+        _tavern.AvailableCards.Add(contractActionWithCoin2);
 
         // Card with Acquire
-        _sut.Hand.Add(GlobalCardDatabase.Instance.GetCard(CardId.CUSTOMS_SEIZURE));
-        
-        var chain = _sut.PlayCard(CardId.CUSTOMS_SEIZURE, _enemy, _tavern);
+        var cardToPlay = GlobalCardDatabase.Instance.GetCard(CardId.CUSTOMS_SEIZURE);
+        _sut.Hand.Add(cardToPlay);
+
+        var chain = _sut.PlayCard(cardToPlay, _enemy, _tavern);
 
         var counter = 0;
 
@@ -28,8 +29,8 @@ public class PlayerTests
                 // Should be choice for which card to Acquire
                 case 0:
                 {
-                    var choice = result as Choice<CardId>;
-                    var newResult = choice.Choose(CardId.KWAMA_EGG_MINE);
+                    var choice = result as Choice<Card>;
+                    var newResult = choice.Choose(contractActionWithCoin2);
                     Assert.True(newResult is Success);
                     break;
                 }
@@ -46,5 +47,22 @@ public class PlayerTests
         }
         
         Assert.Equal(2, counter);
+    }
+
+    [Fact]
+    void DestroyShouldCorrectlyDestroyInHandOrAgents()
+    {
+        var agentInHand = GlobalCardDatabase.Instance.GetCard(CardId.OATHMAN);
+        var agentInPlay = GlobalCardDatabase.Instance.GetCard(CardId.OATHMAN);
+        
+        _sut.Hand.Add(agentInHand);
+        _sut.Agents.Add(agentInPlay);
+        
+        _sut.Destroy(agentInHand);
+        Assert.Empty(_sut.Hand);
+        Assert.Single(_sut.Agents);
+        
+        _sut.Destroy(agentInPlay);
+        Assert.Empty(_sut.Agents);
     }
 }

--- a/Tests/Board/TavernTests.cs
+++ b/Tests/Board/TavernTests.cs
@@ -55,11 +55,12 @@ namespace Tests.Board
         [Fact]
         public void ReplaceCardTest()
         {
+            var cardToReplace = GlobalCardDatabase.Instance.GetCard(CardId.OATHMAN);
             this._tavern.AvailableCards = new List<Card>()
             {
                 GlobalCardDatabase.Instance.GetCard(CardId.CURRENCY_EXCHANGE),
                 GlobalCardDatabase.Instance.GetCard(CardId.LUXURY_EXPORTS),
-                GlobalCardDatabase.Instance.GetCard(CardId.OATHMAN),
+                cardToReplace,
                 GlobalCardDatabase.Instance.GetCard(CardId.CONQUEST),
                 GlobalCardDatabase.Instance.GetCard(CardId.ANSEIS_VICTORY)
             };
@@ -68,7 +69,7 @@ namespace Tests.Board
                 CardId.OATHMAN,
                 this._tavern.AvailableCards.Select(card => card.Id)
             );
-            this._tavern.ReplaceCard(CardId.OATHMAN);
+            this._tavern.ReplaceCard(cardToReplace);
 
             Assert.DoesNotContain(
                 CardId.OATHMAN,
@@ -76,7 +77,6 @@ namespace Tests.Board
             );
 
             Assert.Equal(5, this._tavern.AvailableCards.Count);
-
         }
     }
 }

--- a/src/Board/IPlayer.cs
+++ b/src/Board/IPlayer.cs
@@ -12,18 +12,20 @@ public interface IPlayer
     List<Card> Played { get; set; }
     List<Card> Agents { get; set; }
     List<Card> CooldownPile { get; set; }
-    ExecutionChain PlayCard(CardId cardId, IPlayer other, ITavern tavern);
+    ExecutionChain? StartOfTurnEffectsChain { get; }
+    ExecutionChain PlayCard(Card cardId, IPlayer other, ITavern tavern);
     void HandleAcquireDuringExecutionChain(Card card, IPlayer other, ITavern tavern);
     void HealAgent(Guid guid, int amount);
-    void Refresh(CardId cardId);
+    void Refresh(Card cardId);
     void Draw();
     void EndTurn();
     ExecutionChain AcquireCard(Card card, IPlayer enemy, ITavern tavern, bool replacePendingExecutionChain=true);
-    void Toss(CardId cardId);
-    void KnockOut(CardId cardId);
+    void Toss(Card cardId);
+    void Discard(Card card);
+    void KnockOut(Card cardId);
     void AddToCooldownPile(Card card);
-    void DestroyInHand(CardId cardId);
-    void DestroyAgent(CardId cardId);
+    void Destroy(Card cardId);
     string ToString();
     List<Card> GetAllPlayersCards();
+    void AddStartOfTurnEffects(ExecutionChain chain);
 }

--- a/src/Board/ITavern.cs
+++ b/src/Board/ITavern.cs
@@ -6,7 +6,7 @@ public interface ITavern
     List<Card> AvailableCards { get; set; }
     void DrawCards();
     void ShuffleBack();
-    Card Acquire(CardId card);
+    Card Acquire(Card card);
     List<Card> GetAffordableCards(int coin);
-    void ReplaceCard(CardId card);
+    void ReplaceCard(Card card);
 }

--- a/src/Board/Location.cs
+++ b/src/Board/Location.cs
@@ -1,7 +1,0 @@
-﻿namespace TalesOfTribute;
-
-public enum Location
-{
-    HAND,
-    BOARD,
-}

--- a/src/Board/PlayResult.cs
+++ b/src/Board/PlayResult.cs
@@ -29,6 +29,7 @@ public class Choice<T> : BaseChoice
 {
     public List<T> PossibleChoices { get; }
     public int MaxChoiceAmount { get; } = 1;
+    public int MinChoiceAmount { get; } = 0;
 
     public delegate PlayResult ChoiceCallback(List<T> t);
 
@@ -37,7 +38,7 @@ public class Choice<T> : BaseChoice
     public Choice(List<T> possibleChoices, ChoiceCallback callback) : base()
     {
         // Make sure choice of incorrect type is not created by mistake.
-        if (typeof(T) != typeof(CardId) && typeof(T) != typeof(EffectType) && typeof(T) != typeof(Location))
+        if (typeof(T) != typeof(CardId) && typeof(T) != typeof(EffectType) && typeof(T) != typeof(Card))
         {
             throw new Exception("Choice can only be made for cards or effects!");
         }
@@ -46,7 +47,7 @@ public class Choice<T> : BaseChoice
         _callback = callback;
     }
 
-    public Choice(List<T> possibleChoices, int maxChoiceAmount, ChoiceCallback callback) : this(possibleChoices, callback)
+    public Choice(List<T> possibleChoices, ChoiceCallback callback, int maxChoiceAmount, int minChoiceAmount = 0) : this(possibleChoices, callback)
     {
         if (maxChoiceAmount > possibleChoices.Count)
         {
@@ -54,11 +55,12 @@ public class Choice<T> : BaseChoice
         }
 
         MaxChoiceAmount = maxChoiceAmount;
+        MinChoiceAmount = minChoiceAmount;
     }
 
     public PlayResult Choose(T t)
     {
-        if (!PossibleChoices.Contains(t))
+        if (!PossibleChoices.Contains(t) || MinChoiceAmount > 1)
         {
             return new Failure("Invalid choice specified!");
         }
@@ -72,7 +74,7 @@ public class Choice<T> : BaseChoice
     public PlayResult Choose(List<T> choices)
     {
         // Check if all choices are in possible choices.
-        if (choices.Except(PossibleChoices).Any() || choices.Count > MaxChoiceAmount)
+        if (choices.Except(PossibleChoices).Any() || choices.Count > MaxChoiceAmount || choices.Count < MinChoiceAmount)
         {
             return new Failure("Invalid choices specified!");
         }

--- a/src/Board/Tavern.cs
+++ b/src/Board/Tavern.cs
@@ -33,13 +33,16 @@
             AvailableCards = new List<Card>(5);
         }
 
-        public Card Acquire(CardId card)
+        public Card Acquire(Card card)
         {
-            Card toReturn = this.AvailableCards.First(c => c.Id == card);
-            this.AvailableCards.Remove(toReturn);
-            this.AvailableCards.Add(this.Cards.First());
-            this.Cards.RemoveAt(0);
-            return toReturn;
+            if (!AvailableCards.Contains(card))
+            {
+                throw new Exception($"Card {card.Id} is not available!");
+            }
+            AvailableCards.Remove(card);
+            AvailableCards.Add(this.Cards.First());
+            Cards.RemoveAt(0);
+            return card;
         }
 
         public List<Card> GetAffordableCards(int coin)
@@ -47,14 +50,13 @@
             return this.AvailableCards.Where(card => card.Cost <= coin).ToList();
         }
 
-        public void ReplaceCard(CardId card)
+        public void ReplaceCard(Card toReplace)
         {
-            Card replaced = this.AvailableCards.First(c => c.Id == card);
-            Card replacer = this.Cards.First();
-            this.Cards.Remove(replacer);
-            this.Cards.Add(replaced);
-            this.AvailableCards.Remove(replaced);
-            this.AvailableCards.Add(replacer);
+            Card newCard = Cards.First();
+            Cards.Remove(newCard);
+            Cards.Add(toReplace);
+            AvailableCards.Remove(toReplace);
+            AvailableCards.Add(newCard);
         }
     }
 }


### PR DESCRIPTION
In previous commits, I added Guid field to card, so each card is unique now.

Thanks to this, we can start using Card instead of CardId when Player needs to choose a card. Thanks to Guid parameter, this card can still be found easily, and furthermore, it makes implementing effects such as Destroy much easier. We can also now track exact position of given card copy on Board or in Hand.